### PR TITLE
[FE] Feat/Textarea component, Resetting CSS 추가, Root CSS 변경

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -1,42 +1,50 @@
 #root {
-  max-width: 1280px;
+  max-width: 1060px;
   margin: 0 auto;
   padding: 2rem;
-  text-align: center;
+  color:#333333;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
 }
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+body {
+	line-height: 1;
 }
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+ol, ul {
+	list-style: none;
 }
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+blockquote, q {
+	quotes: none;
 }
-
-.card {
-  padding: 2em;
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
 }
-
-.read-the-docs {
-  color: #888;
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
 }

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,17 +1,10 @@
 import './App.css';
-import DisabledButton from './Components/Button/DisabledButton';
-import MainButton from './Components/Button/MainButton';
-import OutlineButton from './Components/Button/OutlineButton';
-import SubButton from './Components/Button/SubButton';
+import TextArea from './Components/Commons/TextArea';
 
 function App() {
 
   return (
   <>
-    <MainButton></MainButton>
-    <SubButton></SubButton>
-    <OutlineButton></OutlineButton>
-    <DisabledButton></DisabledButton>
   </>
   );
 }

--- a/app/src/Assets/ColorTheme.jsx
+++ b/app/src/Assets/ColorTheme.jsx
@@ -8,4 +8,5 @@ export const Colors = {
   Gray3: '#999999',
   Gray4: '#333333',
   Bgwhite: '#ffffff',
+  Error: '#ff2727',
 };

--- a/app/src/Components/Commons/TextArea.jsx
+++ b/app/src/Components/Commons/TextArea.jsx
@@ -1,0 +1,60 @@
+import styled from 'styled-components';
+import { Colors } from '../../Assets/ColorTheme';
+
+function TextArea({title, subtitle, value, placeholder, onChange, onFocus, onBlur, className, errorMessage}){
+    return(
+        <>
+            <TitleStyled>{title}</TitleStyled>
+            <SubtitleStyled className={className}>{subtitle}</SubtitleStyled>
+            <TextareaStyled value={value}
+            placeholder={placeholder}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            >{value}
+            </TextareaStyled>
+            <ErrorStyled className={className}>{errorMessage}</ErrorStyled>
+        </>
+    )
+}
+
+export default TextArea;
+
+const TitleStyled = styled.h3`
+    margin:0;
+    font-size: 16px;
+    font-weight: 700;
+    color:${Colors.Gray4}
+`
+const SubtitleStyled = styled.p`
+    margin: 4px 0 4px;  
+    font-size: 13px;
+    font-weight: 400;
+    &.hide{
+        display:none;
+    }
+`
+
+const TextareaStyled = styled.textarea`
+    width: ${props => props.width || '400px'};
+    height: ${props => props.height || '56px'};
+    padding: 16px;
+    margin:8px 0 0;
+    border: 1px solid ${Colors.Gray2};
+    border-radius: 16px;
+    box-sizing:border-box;
+    background-color: ${Colors.Bgwhite};
+    color:${Colors.Gray4}
+    font-size:16px;
+    line-height:24px;
+`
+const ErrorStyled = styled.p`
+    margin: 0;
+    font-size: 12px;
+    font-weight: 400;
+    color: ${Colors.Error};
+    line-height: 18px;
+    &.hide{
+        display:none;
+    }
+`


### PR DESCRIPTION
## 📷 Screen Shot
<!-- 스크린샷이 필요하다면 첨부합니다 -->
<img width="582" alt="스크린샷 2023-07-04 오후 5 47 44" src="https://github.com/codestates-seb/seb44_main_015/assets/124794790/02acde73-cd76-4833-9066-3bd5a7be1be5">
<img width="400" alt="스크린샷 2023-07-04 오후 5 47 47" src="https://github.com/codestates-seb/seb44_main_015/assets/124794790/8207136d-e40a-415d-ad5e-2970775f0430">

## 📌 Summary
<!-- 해당 PR에 대해 요약을 작성합니다 -->
Textarea에 Title, Subtitle, Textarea, ErrorMessage 추가했습니다. onChange, onBlur 등까지 prop으로 전부 전달 가능합니다.
height값도 조절 가능하니 참고해주세요!

## ✨ Describe your changes
<!-- 변경 내용을 작성합니다, 이슈처럼 체크박스를 활용해도 좋습니다.-->
- Textarea를 만들면서 CSS들이 리셋이 안되어있는 것을 발견하여 CSS Reset하는 코드들을 추가했습니다.
- CSS -> #root 에 width값 1260 => 1060으로 변경하였습니다
- CSS -> #root 에 color(폰트 컬러) #333333으로 기본 변경하였습니다.

## 📚 Issue number and link
<!-- 해당 PR에 관련된 Issue 번호를 기입합니다 -->
