### PR TITLE
[FE] Feat:LogIn Page 마크업&CSS 완료

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@700&display=swap');
+
 #root {
   /* max-width: 1060px;
   margin: 0 auto; */

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,12 +1,7 @@
 import './App.css';
-import LogIn from './Pages/LogIn';
 
 function App() {
-  return (
-    <>
-      <LogIn />
-    </>
-  );
+  return <></>;
 }
 
 export default App;

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,7 +1,12 @@
 import './App.css';
+import LogIn from './Pages/LogIn';
 
 function App() {
-  return <></>;
+  return (
+    <>
+      <LogIn />
+    </>
+  );
 }
 
 export default App;

--- a/app/src/Components/Button/DisabledButton.jsx
+++ b/app/src/Components/Button/DisabledButton.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Colors } from '../../Assets/ColorTheme';
+import { Colors } from '../../Assets/Theme';
 
 function DisabledButton({content, width, backgroundColor}){
 
@@ -21,4 +21,6 @@ const ButtonStyled = styled.button`
     border-radius: 16px;
     border:none;
     cursor:pointer;
+    line-height:24px;
+    font-size:16px;
 `

--- a/app/src/Components/Button/MainButton.jsx
+++ b/app/src/Components/Button/MainButton.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Colors } from '../../Assets/ColorTheme';
+import { Colors } from '../../Assets/Theme';
 
 function MainButton({content, width}){
 
@@ -23,6 +23,8 @@ const ButtonStyled = styled.button`
   border:none;
   cursor:pointer;
   transition:0.3s;
+  line-height:24px;
+  font-size:16px;
   &:hover{
     background-color:${Colors.secondPurple};
   }

--- a/app/src/Components/Button/OutlineButton.jsx
+++ b/app/src/Components/Button/OutlineButton.jsx
@@ -19,4 +19,6 @@ const ButtonStyled = styled.button`
   border: 1px solid ${Colors.mainPurple};
   cursor: pointer;
   transition: 0.3s;
+  line-height:24px;
+  font-size:16px;
 `;

--- a/app/src/Components/Button/SubButton.jsx
+++ b/app/src/Components/Button/SubButton.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Colors } from '../../Assets/ColorTheme';
+import { Colors } from '../../Assets/Theme';
 
 function SubButton({content, width}){
 
@@ -23,4 +23,6 @@ const ButtonStyled = styled.button`
     border:none;
     cursor:pointer;
     transition:0.3s;
+    line-height:24px;
+    font-size:16px;
 `

--- a/app/src/Components/Commons/Tag.jsx
+++ b/app/src/Components/Commons/Tag.jsx
@@ -35,21 +35,24 @@ export const TagStyled = styled.li`
   background-color: ${(props) => props.backgroundColor || `${Colors.Bgwhite}`};
 
     &.mediumSelected{
-      padding:16px;
+      padding:16px 0 16px;
       width: 192px;
       border: 1px solid ${Colors.mainPurple};
+      background-color: ${Colors.thirdPurple};
       font-size:16px;
       font-weight:700;
       box-sizing:border-box;
+      cursor:pointer;
     }
 
     &.mediumUnSelected{
-      padding:16px;
+      padding:16px 0 16px;
       width:192px;
       border:1px solid ${Colors.Gray2};
       font-size:16px;
       color:${Colors.Gray3};
       font-weight:400;
+      cursor:pointer;
     }
 `;
 

--- a/app/src/Components/Commons/TextArea.jsx
+++ b/app/src/Components/Commons/TextArea.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Colors } from '../../Assets/ColorTheme';
+import { Colors } from '../../Assets/Theme';
 
 function TextArea({
   title,
@@ -59,6 +59,12 @@ const TextareaStyled = styled.textarea`
   color: ${Colors.Gray4};
   font-size: 16px;
   line-height: 24px;
+  resize:none;
+  font-weight:400;
+  font-family: 'Noto Sans KR', sans-serif;
+  &::placeholder {
+    color: ${Colors.Gray2};
+  }
 `;
 
 const ErrorStyled = styled.p`

--- a/app/src/Pages/LogIn.jsx
+++ b/app/src/Pages/LogIn.jsx
@@ -1,0 +1,164 @@
+import styled from 'styled-components';
+import { useState, useEffect } from 'react';
+import {Colors} from '../Assets/Theme';
+import Tag from '../Components/Commons/Tag';
+import TextArea from '../Components/Commons/TextArea';
+import MainButton from '../Components/Button/MainButton';
+
+import Logo from '../Assets/Icons/Logo.png';
+
+function LogIn(){
+    const [focusTag, setFocusTag] = useState("freelancer");
+    
+    const handleFocusTag = (tag) => () => {
+        setFocusTag(tag);
+    }
+
+    return(
+        <BodyBackgroundStyled>
+            <MainStyled>
+                <HomeLinkWrapperStyled>
+                    <HomeLinkStyled>홈으로</HomeLinkStyled>
+                </HomeLinkWrapperStyled>
+                <LogInWrapperStyled>
+                    <LogoWrapperStyled>
+                        <h2><LogoStyled src={Logo} alt="프리해요"></LogoStyled></h2>
+                        <NoticeStyled>프리랜서/회사 유형을 선택 후<br></br>로그인 해 주세요</NoticeStyled>
+                    </LogoWrapperStyled>
+                    <TagWrapperStyled>
+                        <Tag
+                        children={"🧑‍💻 프리랜서"} 
+                        className={focusTag === "freelancer" ? "mediumSelected" : "mediumUnSelected"}
+                        onClick={handleFocusTag("freelancer")}
+                        />
+                        <Tag children={"🏢 회사 · 의뢰인"}
+                        className={focusTag === "company" ? "mediumSelected" : "mediumUnSelected"}
+                        onClick={handleFocusTag("company")}
+                        />
+                    </TagWrapperStyled>
+                    <TextAreaWrapperStyled>
+                        <li>
+                            <TextArea
+                            title={"이메일"}
+                            placeholder={"이메일을 입력해주세요"}
+                            errorMessage={"일치하는 회원 정보가 없습니다"}
+                            className={"hide"}
+                            />
+                        </li>
+                        <li>
+                            <TextArea 
+                            title={"비밀번호"}
+                            placeholder={"비밀번호를 입력해주세요"}
+                            />
+                        </li>
+                    </TextAreaWrapperStyled>
+                    <MainButton width={"100%"} content={"로그인"}/>
+                    <SignUpWrapperStyled>
+                        <SignUpNoticeStyled>아직 회원이 아니신가요?</SignUpNoticeStyled>
+                        <SignUpStyled>회원가입</SignUpStyled>
+                    </SignUpWrapperStyled>
+                </LogInWrapperStyled>
+            </MainStyled>
+        </BodyBackgroundStyled>
+    )
+}
+
+export default LogIn;
+
+const BodyBackgroundStyled = styled.div`
+    background-color:${Colors.Gray1};
+    height:100%;
+`
+
+const MainStyled = styled.main`
+    padding:0 0 24px;
+    text-align:right;
+`
+
+const HomeLinkWrapperStyled = styled.div`
+    padding: 8px 0 8px;
+`
+
+const HomeLinkStyled = styled.a`
+    text-align: right;
+    lineheight: 36px;
+    font-size: 14px;
+    color: ${Colors.Gray3};
+    font-weight:400;
+    cursor:pointer;
+`
+
+const LogInWrapperStyled = styled.form`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 40px auto 132px;
+    padding: 80px 60px 80px;
+    width: 520px;
+    height: 100%;
+    text-align:left;
+    background-color:${Colors.Bgwhite};
+    border: 1px solid ${Colors.Gray2};
+    border-radius:16px;
+    box-sizing:border-box;
+`
+
+const LogoWrapperStyled = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+`
+
+const LogoStyled = styled.img`
+    width:108px;
+    height: 22px;
+`
+
+const NoticeStyled = styled.p`
+    margin: 16px 0 0;
+    font-size: 16px;
+    font-weight: 400;
+    color: ${Colors.Gray3};
+    text-align:center;
+    line-height:24px;
+`
+
+const TagWrapperStyled = styled.ul`
+    display:flex;
+    width:100%;
+    margin: 24px 0 40px;
+    gap:16px;
+`
+
+const TextAreaWrapperStyled = styled.ul`
+    margin-bottom: 56px;
+    & > li:first-child{
+        margin-bottom: 10px;
+    }
+`
+const SignUpWrapperStyled = styled.div`
+    display:flex;
+    margin-top:32px;
+    align-items:center;
+`
+
+const SignUpNoticeStyled = styled.p`
+    color: ${Colors.Gray4};
+    line-height:24px;
+    &:after{
+        content: "";
+        display: inline-block;
+        width: 1px;
+        height: 24px;
+        margin: 0 16px 0;
+        background-color: ${Colors.Gray2};
+        vertical-align:middle;
+    }
+`
+
+const SignUpStyled = styled.a`
+    font-size: 16px;
+    font-weight: 700;
+    color: ${Colors.mainPurple};
+    cursor:pointer;
+`

--- a/app/src/Pages/LogIn.jsx
+++ b/app/src/Pages/LogIn.jsx
@@ -1,9 +1,11 @@
-import styled from 'styled-components';
-import { useState, useEffect } from 'react';
 import {Colors} from '../Assets/Theme';
 import Tag from '../Components/Commons/Tag';
 import TextArea from '../Components/Commons/TextArea';
 import MainButton from '../Components/Button/MainButton';
+
+import { useState, useEffect } from 'react';
+
+import styled from 'styled-components';
 
 import Logo from '../Assets/Icons/Logo.png';
 


### PR DESCRIPTION
## 📷 Screen Shot

<!-- 스크린샷이 필요하다면 첨부합니다 -->
<img width="1365" alt="스크린샷 2023-07-07 오후 3 48 34" src="https://github.com/codestates-seb/seb44_main_015/assets/124794790/311f529b-afde-4d8f-82d7-90322b0f3bbd">


## 📌 Summary

<!-- 해당 PR에 대해 요약을 작성합니다 -->
로그인 페이지 마크업/CSS 완료

## ✨ Describe your changes

<!-- 변경 내용을 작성합니다, 이슈처럼 체크박스를 활용해도 좋습니다. -->
- 작업하면서 Tag 컴포넌트 안의 medium 사이즈 태그들 CSS 수정했습니다.
- 작업하면서 TextArea 컴포넌트 안에 placeholder, font-family 등을 수정했습니다.
- App.css에 Noto Sans KR 폰트패밀리 임포트하여 #root CSS에 추가하였습니다.
- 아직 비밀번호가 텍스트로 보입니다. 이건 차후 TextArea Component 수정하겠습니다.

## 💬 Other comments

<!-- 기타 사항을 적습니다 --->
- 아직 마크업/CSS만 완료된 상태입니다~

## 🔢 Issue number and link

<!-- 해당 PR에 관련된 Issue 번호를 기입합니다 -->
[FE] MEM007_로그인

- [x] 프리랜서와 회사 중 타입을 선택한다.
- [ ] email : 등록된 이메일이어야 한다. 아닐시에 입력칸 밑에 오류메세지를 출력한다.
- [ ] 로그인 성공 시 메인페이지로 이동시킨다.
- [x] 로그인 버튼 밑에 회원가입 버튼을 추가한다.
