### PR TITLE
[FE] Feat: 채용리스트 페이지 UI v.1.0.0

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,6 +1,6 @@
 import './App.css';
 import Main from './Pages/Main';
-import EmploymentPage from './Pages/EmploymentPage';
+import EmploymentPage from './Pages/EmploymentList';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 function App() {

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,12 +1,13 @@
 import './App.css';
-import MainPage from './Pages/MainPage/MainPage';
+import Main from './Pages/Main';
+import EmploymentPage from './Pages/EmploymentPage';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<MainPage />}></Route>
+        <Route path="/" element={<EmploymentPage />}></Route>
       </Routes>
     </BrowserRouter>
   );

--- a/app/src/Components/Commons/EmploymentCard.jsx
+++ b/app/src/Components/Commons/EmploymentCard.jsx
@@ -1,5 +1,5 @@
 import NoLineTag from './NoLineTag';
-import FakeEmploymentInfo from '../../Api/FakeEmploymentInfo.json';
+
 import { Colors } from '../../Assets/Theme';
 import { styled } from 'styled-components';
 

--- a/app/src/Components/Commons/EmploymentPage/EmploymentCardList.jsx
+++ b/app/src/Components/Commons/EmploymentPage/EmploymentCardList.jsx
@@ -7,7 +7,7 @@ const EmploymentCardList = () => {
 
   return (
     <>
-      <NewEmploymentContainerStyled>
+      <LowerContainerStyled>
         <EmploymentCardContainerStyled>
           {employmentData.map((employmentInfo) => (
             <EmploymentCard
@@ -16,14 +16,14 @@ const EmploymentCardList = () => {
             />
           ))}
         </EmploymentCardContainerStyled>
-      </NewEmploymentContainerStyled>
+      </LowerContainerStyled>
     </>
   );
 };
 
 export default EmploymentCardList;
 
-const NewEmploymentContainerStyled = styled.section`
+const LowerContainerStyled = styled.section`
   display: flex;
   flex-wrap: wrap;
   height: 100%;

--- a/app/src/Components/Commons/EmploymentPage/EmploymentCardList.jsx
+++ b/app/src/Components/Commons/EmploymentPage/EmploymentCardList.jsx
@@ -1,15 +1,13 @@
-import EmploymentCard from '../../Components/Commons/EmploymentCard';
-import FakeEmploymentInfo from '../../Api/FakeEmploymentInfo.json';
-import { Colors } from '../../Assets/Theme';
+import EmploymentCard from '../EmploymentCard';
+import FakeEmploymentInfo from '../../../Api/FakeEmploymentInfo.json';
 import { styled } from 'styled-components';
 
-const NewEmployment = () => {
-  const employmentData = FakeEmploymentInfo.slice(0, 4);
+const EmploymentCardList = () => {
+  const employmentData = FakeEmploymentInfo;
 
   return (
     <>
       <NewEmploymentContainerStyled>
-        <TitleStyled>⚡ 신규 채용</TitleStyled>
         <EmploymentCardContainerStyled>
           {employmentData.map((employmentInfo) => (
             <EmploymentCard
@@ -23,26 +21,21 @@ const NewEmployment = () => {
   );
 };
 
-export default NewEmployment;
+export default EmploymentCardList;
 
 const NewEmploymentContainerStyled = styled.section`
   display: flex;
-  flex-direction: column;
-  margin-bottom: 80px;
-`;
-
-const TitleStyled = styled.h3`
-  margin-bottom: 41px;
-  color: ${Colors.Gray4};
-  font-size: 24px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 35px;
-  text-align: center;
+  flex-wrap: wrap;
+  height: 100%;
+  padding: 40px 190px 40px 190px;
+  box-sizing: border-box;
+  align-items: center;
+  justify-content: center;
 `;
 
 const EmploymentCardContainerStyled = styled.ul`
   display: flex;
+  flex-wrap: wrap; // 너비를 벗어나면 밑으로 내려가게 함
   flex-direction: row;
   gap: 22px;
 `;

--- a/app/src/Components/Commons/EmploymentPage/TagList.jsx
+++ b/app/src/Components/Commons/EmploymentPage/TagList.jsx
@@ -1,0 +1,70 @@
+import { styled } from 'styled-components';
+import { Colors } from '../../../Assets/Theme';
+
+const TagList = () => {
+  return (
+    <>
+      <TagListWrapperStyled>
+        <TagListContainerStyled>
+          <TagStyled>연봉 상위 1%</TagStyled>
+          <TagStyled>연봉 상위 5%</TagStyled>
+          <TagStyled>연봉 상위 5%</TagStyled>
+          <TagStyled>연봉 상위 5%</TagStyled>
+          <TagStyled>연봉 상위 5%</TagStyled>
+          <TagStyled>연봉 상위 5%</TagStyled>
+          <TagStyled>연봉 상위 5%</TagStyled>
+          <TagStyled>연봉 상위 5%</TagStyled>
+          <TagStyled>연봉 상위 5%</TagStyled>
+          <TagStyled>연봉 상위 5%</TagStyled>
+          <TagStyled>연봉 상위 5%</TagStyled>
+          <TagStyled>연봉 상위 5%</TagStyled>
+          <TagStyled>연봉 상위 5%</TagStyled>
+          <TagStyled>연봉 상위 5%</TagStyled>
+          <TagStyled>연봉 상위 5%</TagStyled>
+          <TagStyled>연봉 상위 5%</TagStyled>
+        </TagListContainerStyled>
+      </TagListWrapperStyled>
+    </>
+  );
+};
+
+export default TagList;
+const TagListWrapperStyled = styled.div`
+  display: flex;
+  height: 212px;
+  width: 100%;
+  border-bottom: 1px solid ${Colors.Gray2};
+  align-items: center;
+`;
+
+const TagListContainerStyled = styled.div`
+  min-width: 1440px;
+  width: 100%;
+  display: flex;
+  box-sizing: border-box;
+  padding: 80px 190px 30px 190px;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+`;
+const TagStyled = styled.div`
+  display: flex;
+  padding: 8px 12px;
+  gap: 8px;
+  white-space: nowrap;
+  background-color: ${Colors.Gray1};
+  border: 1px solid transparent;
+  border-radius: 16px;
+  color: ${Colors.Gray4};
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 300px;
+
+  &:hover {
+    background-color: ${Colors.Bgwhite};
+    border-color: ${Colors.mainPurple};
+    color: ${Colors.mainPurple};
+    font-weight: 400px;
+  }
+`;

--- a/app/src/Components/Commons/EmploymentPage/TagList.jsx
+++ b/app/src/Components/Commons/EmploymentPage/TagList.jsx
@@ -4,8 +4,8 @@ import { Colors } from '../../../Assets/Theme';
 const TagList = () => {
   return (
     <>
-      <TagListWrapperStyled>
-        <TagListContainerStyled>
+      <UpperContainerStyled>
+        <TagContainerStyled>
           <TagStyled>연봉 상위 1%</TagStyled>
           <TagStyled>연봉 상위 5%</TagStyled>
           <TagStyled>연봉 상위 5%</TagStyled>
@@ -22,14 +22,14 @@ const TagList = () => {
           <TagStyled>연봉 상위 5%</TagStyled>
           <TagStyled>연봉 상위 5%</TagStyled>
           <TagStyled>연봉 상위 5%</TagStyled>
-        </TagListContainerStyled>
-      </TagListWrapperStyled>
+        </TagContainerStyled>
+      </UpperContainerStyled>
     </>
   );
 };
 
 export default TagList;
-const TagListWrapperStyled = styled.div`
+const UpperContainerStyled = styled.div`
   display: flex;
   height: 212px;
   width: 100%;
@@ -37,7 +37,7 @@ const TagListWrapperStyled = styled.div`
   align-items: center;
 `;
 
-const TagListContainerStyled = styled.div`
+const TagContainerStyled = styled.div`
   min-width: 1440px;
   width: 100%;
   display: flex;
@@ -66,5 +66,6 @@ const TagStyled = styled.div`
     border-color: ${Colors.mainPurple};
     color: ${Colors.mainPurple};
     font-weight: 400px;
+    cursor: pointer;
   }
 `;

--- a/app/src/Components/Commons/MainPage/Banner.jsx
+++ b/app/src/Components/Commons/MainPage/Banner.jsx
@@ -1,6 +1,6 @@
-import { Colors } from '../../Assets/Theme';
+import { Colors } from '../../../Assets/Theme';
 import { styled } from 'styled-components';
-import BannerImg from '../../Assets/Icons/BannerImg.png';
+import BannerImg from '../../../Assets/Icons/BannerImg.png';
 
 const Banner = () => {
   return (

--- a/app/src/Components/Commons/MainPage/CardOfTheWeek.jsx
+++ b/app/src/Components/Commons/MainPage/CardOfTheWeek.jsx
@@ -1,6 +1,6 @@
-import NameCard from '../../Components/Commons/NameCard';
-import FakeUserInfo from '../../Api/FakeUserInfo.json';
-import { Colors } from '../../Assets/Theme';
+import NameCard from '../../Commons/NameCard';
+import FakeUserInfo from '../../../Api/FakeUserInfo.json';
+import { Colors } from '../../../Assets/Theme';
 import { styled } from 'styled-components';
 
 const CardOfTheWeek = () => {

--- a/app/src/Components/Commons/MainPage/NewEmployment.jsx
+++ b/app/src/Components/Commons/MainPage/NewEmployment.jsx
@@ -1,0 +1,48 @@
+import EmploymentCard from '../../../Components/Commons/EmploymentCard';
+import FakeEmploymentInfo from '../../../Api/FakeEmploymentInfo.json';
+import { Colors } from '../../../Assets/Theme';
+import { styled } from 'styled-components';
+
+const NewEmployment = () => {
+  const employmentData = FakeEmploymentInfo.slice(0, 4);
+
+  return (
+    <>
+      <NewEmploymentContainerStyled>
+        <TitleStyled>⚡ 신규 채용</TitleStyled>
+        <EmploymentCardContainerStyled>
+          {employmentData.map((employmentInfo) => (
+            <EmploymentCard
+              key={employmentInfo.id}
+              employmentInfo={employmentInfo}
+            />
+          ))}
+        </EmploymentCardContainerStyled>
+      </NewEmploymentContainerStyled>
+    </>
+  );
+};
+
+export default NewEmployment;
+
+const NewEmploymentContainerStyled = styled.section`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 80px;
+`;
+
+const TitleStyled = styled.h3`
+  margin-bottom: 41px;
+  color: ${Colors.Gray4};
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 35px;
+  text-align: center;
+`;
+
+const EmploymentCardContainerStyled = styled.ul`
+  display: flex;
+  flex-direction: row;
+  gap: 22px;
+`;

--- a/app/src/Components/Commons/MainPage/SecondBanner.jsx
+++ b/app/src/Components/Commons/MainPage/SecondBanner.jsx
@@ -1,6 +1,6 @@
-import { Colors } from '../../Assets/Theme';
+import { Colors } from '../../../Assets/Theme';
 import { styled } from 'styled-components';
-import SecondBannerImg from '../../Assets/Icons/SecondBannerImg.png';
+import SecondBannerImg from '../../../Assets/Icons/SecondBannerImg.png';
 
 const SecondBanner = () => {
   return (

--- a/app/src/Pages/EmploymentList.jsx
+++ b/app/src/Pages/EmploymentList.jsx
@@ -21,11 +21,11 @@ export default EmploymentPage;
 
 const EmploymentPageContainerStyled = styled.div`
   display: flex;
-  min-width: 1080px;
-  height: auto;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  min-width: 1080px;
+  height: auto;
   box-sizing: border-box;
   overflow-x: auto;
 `;

--- a/app/src/Pages/EmploymentPage.jsx
+++ b/app/src/Pages/EmploymentPage.jsx
@@ -1,0 +1,31 @@
+import Header from '../Components/Commons/Layouts/Header';
+import Footer from '../Components/Commons/Layouts/Footer';
+import TagList from '../Components/Commons/EmploymentPage/TagList';
+import EmploymentCardList from '../Components/Commons/EmploymentPage/EmploymentCardList';
+import { styled } from 'styled-components';
+
+const EmploymentPage = () => {
+  return (
+    <>
+      <Header />
+      <EmploymentPageContainerStyled>
+        <TagList />
+        <EmploymentCardList></EmploymentCardList>
+      </EmploymentPageContainerStyled>
+      <Footer />
+    </>
+  );
+};
+
+export default EmploymentPage;
+
+const EmploymentPageContainerStyled = styled.div`
+  display: flex;
+  min-width: 1080px;
+  height: auto;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  overflow-x: auto;
+`;

--- a/app/src/Pages/LogIn.jsx
+++ b/app/src/Pages/LogIn.jsx
@@ -94,7 +94,7 @@ const HomeLinkWrapperStyled = styled.div`
 
 const HomeLinkStyled = styled.a`
   text-align: right;
-  lineheight: 36px;
+  line-height: 36px;
   font-size: 14px;
   color: ${Colors.Gray3};
   font-weight: 400;

--- a/app/src/Pages/Main.jsx
+++ b/app/src/Pages/Main.jsx
@@ -1,9 +1,9 @@
-import Header from '../../Components/Commons/Layouts/Header';
-import Footer from '../../Components/Commons/Layouts/Footer';
-import Banner from './Banner';
-import SecoondBanner from './SecondBanner';
-import NewEmployment from './NewEmployment';
-import CardOfTheWeek from './CardOfTheWeek';
+import Header from '../Components/Commons/Layouts/Header';
+import Footer from '../Components/Commons/Layouts/Footer';
+import Banner from '../Components/Commons/MainPage//Banner';
+import SecoondBanner from '../Components/Commons/MainPage/SecondBanner';
+import NewEmployment from '../Components/Commons/MainPage/NewEmployment';
+import CardOfTheWeek from '../Components/Commons/MainPage/CardOfTheWeek';
 import { styled } from 'styled-components';
 
 const MainPage = () => {


### PR DESCRIPTION
## 📷 Screen Shot

<!-- 스크린샷이 필요하다면 첨부합니다 -->
![스크린샷 2023-07-17 오전 10 16 04](https://github.com/codestates-seb/seb44_main_015/assets/124761623/71aa5f30-3789-4c13-a9bd-6df6cbe5bd43)


## 📌 Summary

<!-- 해당 PR에 대해 요약을 작성합니다 -->
채용리스트 페이지 UI 완성입니다.

## ✨ Describe your changes

<!-- 변경 내용을 작성합니다, 이슈처럼 체크박스를 활용해도 좋습니다. -->
- [x] 컴포넌트 : 제목, 회사 이름, 회사 주소, 태그
- [ ] 페이징  : 무한 스크롤
- [ ] 2단계 : 상위 카테고리 해당 태그 클릭 시  연관된 채용 공고만 나열  

## 💬 Other comments

<!-- 기타 사항을 적습니다 --->
무한 스크롤은 방법은 주말동안 공부해둬서 할 수 있을 것 같지만,
목데이터 기반으로 코딩했다가 API 나오고나서 다시 수정하는게 힘들 것 같아 아직 구현안했습니다.
API 나오면 하겠습니다.

## 🔢 Issue number and link

<!-- 해당 PR에 관련된 Issue 번호를 기입합니다 -->
#20 [FE] EP002_채용 리스트(5h)
